### PR TITLE
Fixed broken image link and removed a copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1332,7 +1332,7 @@
             </div>
             <div class="col-lg-4 mb-4">
                 <div class="card">
-                    <img class="card-img-top" src="https://www.google.com/imgres?imgurl=https%3A%2F%2Faguycalledkane.files.wordpress.com%2F2017%2F04%2Fsquirtle.png%3Fw%3D840&imgrefurl=https%3A%2F%2Faguycalledkane.wordpress.com%2F2017%2F04%2F10%2Fbulbasaur-charmander-or-squirtle-an-age-old-question%2F&tbnid=-dOyfKSihBtqFM&vet=12ahUKEwiu9Lnmp5PsAhV39zgGHcGbBOoQMygaegUIARCNAg..i&docid=EUloZF-VOXcezM&w=822&h=1023&q=Squirtle&ved=2ahUKEwiu9Lnmp5PsAhV39zgGHcGbBOoQMygaegUIARCNAg" alt="">
+                    <img class="card-img-top" src="https://aguycalledkane.files.wordpress.com/2017/04/squirtle.png?w=840" alt="">
                     <div class="card-body">
                         <h5 class="card-title">Squirtle</h5>
                         <p class="card-text">Squirtle is a playable Pokémon used by the Pokémon Trainer. It can use Waterfall to recover from falls as well as Withdraw, in which case it retreats to its shell and shoots water from the back of it propelling him forwards. It also uses Water Gun to push enemies with a stream of water.</p>
@@ -1541,18 +1541,6 @@
                     </div>
                 </div>
             </div>    
-	     
-            <div class="col-lg-4 mb-4">
-                <div class="card">
-                    <img class="card-img-top" src="https://www.deviantart.com/uraharataichou/art/143-Snorlax-762472931" alt="Snorlax">
-                    <div class="card-body">
-                        <h5 class="card-title">Snorlax</h5>
-                        <p class="card-text">The laziest pokemon. However, is the most powerful as well.</p>
-                        <a href="https://github.com/CesarCueva19" class="btn btn-outline-danger btn-sm">Contributed by - CesarCueva19</a>
-                    </div>
-                </div>
-            </div>
-            
         <div class="col-lg-4 mb-4">
               <div class="card">
                   <img class="card-img-top" src="https://i.pinimg.com/originals/12/8d/e8/128de8ce51ee0c498a4dfa67610f5843.jpg" alt="Snorlax">


### PR DESCRIPTION
1. I noticed the image link for Squirtle was broken due to which it wasn't showing, so fixed that
![Screenshot 2020-10-02 151019](https://user-images.githubusercontent.com/61850850/94910047-c1b50f80-04c1-11eb-94a3-2a5d0bdfc76a.jpg)

2. There were 2 Snorlax copies by the same person one with a broken image link so removed that one
![Screenshot 2020-10-02 150631](https://user-images.githubusercontent.com/61850850/94910018-b4982080-04c1-11eb-867f-196ef8244e04.jpg)

3. There are still multiple copies of some pokemon I believe