### PR TITLE
Fix broken picture links

### DIFF
--- a/index.html
+++ b/index.html
@@ -956,7 +956,7 @@
       </div>
       <div class="col-lg-4 mb-4">
         <div class="card">
-          <img alt="Solgaleo" class="card-img-top" src="images/Solgaleo.jpg">
+          <img alt="Solgaleo" class="card-img-top" src="images/solgaleo.jpg">
           <div class="card-body">
             <h5 class="card-title">Solgaleo</h5>
             <p class="card-text">Solgaleo is a large, white Pokémon resembling a lion and capable of

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       
       <div class="col-lg-4 mb-4">
         <div class="card">
-            <img class="card-img-top" src="/images/abra.jpg" alt="Abra">
+            <img class="card-img-top" src="images/abra.jpg" alt="Abra">
             <div class="card-body">
                 <h5 class="card-title">Abra</h5>
                 <p class="card-text">Abra uses psychic powers while it sleeps. Its dreams affect the powers that the Pokemon wields.</p>
@@ -3231,7 +3231,7 @@
       </div>
       <div class="col-lg-4 mb-4">
         <div class="card">
-          <img alt="Unown" class="card-img-top" src="/images/Unown.webp">
+          <img alt="Unown" class="card-img-top" src="images/Unown.webp">
           <div class="card-body">
             <h5 class="card-title">Unown</h5>
             <p class="card-text">Unown is a psychic-type Pokemon, It is shaped like an eye with


### PR DESCRIPTION
## Description
Some of the images would not load and showed a broken image instead. These src links had a leading slash and that was preventing it from loading properly. 
### Ex:
* src="/images/abra.jpg" -> src="images/abra.jpg"

## Related Issue
#2 `Welcome Contributors!`