### PR TITLE
Fix: Fixed image links on all missing images

### DIFF
--- a/index.html
+++ b/index.html
@@ -6001,7 +6001,7 @@
                     <div class="card">
                         <img class="card-img-top"
                             src="https://cdn2.bulbagarden.net/upload/4/4f/477Dusknoir.png"
-                            alt="" />
+                            alt="Dusknoir" />
                         <div class="card-body">
                             <h5 class="card-title">Dusknoir</h5>
                             <p class="card-text">Dusknoir is a Ghost Pokémon which evolves from Dusclops.The antenna on


### PR DESCRIPTION
Changed all broken or missing image links, and added correct ones from https://bulbapedia.bulbagarden.net.

I fixed some pokemon images that are duplicates, like _Charizard_, _Ghastly_, and _Metagross_. I figured it would be a cleaner pull request to only fix the broken links, and remove duplicate cards on another one (by me or someone else), as there are a lot of them.